### PR TITLE
fix: Fix undefined task properties in project config, #1

### DIFF
--- a/app/core/projects/import/index.js
+++ b/app/core/projects/import/index.js
@@ -14,6 +14,7 @@ const {
   handleItemPredictionStream,
   handleAnnotationsImportStream,
 } = require('../../file-upload/stream-handler')
+const { projectConfigV2Schema } = require('../../../router/validation/project')
 
 const importAllFromFiles = async ({
   projectFile,
@@ -83,6 +84,7 @@ const createProject = async ({ file, _user, renameIfDuplicateName = false }) => 
   try {
     const configStream = await fs.readFile(file.path, 'utf8')
     config = JSON.parse(configStream)
+    projectConfigV2Schema.validate(config)
   } catch (error) {
     logger.info(error)
     logger.error(error.stack)

--- a/app/core/projects/index.js
+++ b/app/core/projects/index.js
@@ -199,7 +199,7 @@ const createProjectAndTasks = async ({ config, _user }) => {
   const projectId = mongoose.Types.ObjectId()
   const admins = []
   const tasksToInsert = new Map()
-  config.tasks.forEach((task) => {
+  config.tasks?.forEach((task) => {
     const _id = mongoose.Types.ObjectId()
     tasksToInsert.set(_id, {
       _id,


### PR DESCRIPTION
### Description

When creating a new project, annotations, items and prediction are validated against Joi schema, but not the project. Thats why we encountered this [issue](https://github.com/lajavaness/annotto-api/issues/1)

Closes #1 

#### Type of Change

Please delete options that are not relevant (including this descriptive text).

- [x] Bug fix (non-breaking change which fixes an issue)

